### PR TITLE
feat.relations

### DIFF
--- a/src/constants/defalutCatrgories.ts
+++ b/src/constants/defalutCatrgories.ts
@@ -1,0 +1,5 @@
+export const defaultCategoryNames = [
+    { name: '영화', description: '영화 관련 카테고리' },
+    { name: '음악', description: '음악 관련 카테고리' },
+    { name: '책', description: '책 관련 카테고리' },
+];

--- a/src/constants/defaultInterests.ts
+++ b/src/constants/defaultInterests.ts
@@ -1,0 +1,1 @@
+export const defaultInterestNames: string[] = ['버럭', '까칠', '기쁨', '소심', '슬픔'];

--- a/src/modules/category/dto/UserCategoryDto.ts
+++ b/src/modules/category/dto/UserCategoryDto.ts
@@ -1,12 +1,12 @@
 import {Field} from "../../../utils/mapper/FieldNameExtractor";
-import {Category} from "../entity/Category";
+import {ResponseCategoryDto} from "./CategoryDto";
 
 export class ResponseUserCategoryDto {
     @Field
     id: number;
 
     @Field
-    category: Category;
+    name: string;
 
     @Field
     score: number;

--- a/src/modules/category/entity/UserCategory.ts
+++ b/src/modules/category/entity/UserCategory.ts
@@ -15,4 +15,7 @@ export class UserCategory {
 
     @Column({ type: 'int', default: 0 })
     score: number;
+
+    @Column({nullable:true})
+    name: string;
 }

--- a/src/modules/category/repository/UserCatrgoryRepository.ts
+++ b/src/modules/category/repository/UserCatrgoryRepository.ts
@@ -8,15 +8,15 @@ export class UserCategoryRepository extends Repository<UserCategory> {
         super(UserCategory, dataSource.createEntityManager());
     }
 
-    async createUserCategory(userId: number, categoryId: number, score: number): Promise<UserCategory> {
-        const userCategory = this.create({ user: { id: userId }, category: { id: categoryId }, score });
+    async createUserCategory(userId: number, categoryId: number, score: number, name: string): Promise<UserCategory> {
+        const userCategory = this.create({ user: { id: userId }, category: { id: categoryId }, score,name});
         return this.save(userCategory);
     }
 
     async findByUserId(userId: number): Promise<UserCategory[]> {
         return this.find({
             where: { user: { id: userId } },
-            relations: ['category'],
+            relations: ['category','user'],
         });
     }
 

--- a/src/modules/data/category/InitCategoryService.ts
+++ b/src/modules/data/category/InitCategoryService.ts
@@ -2,6 +2,7 @@ import { Injectable, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Category} from "../../category/entity/Category";
+import {defaultCategoryNames} from "../../../constants/defalutCatrgories";
 
 @Injectable()
 export class InitCategoryService implements OnModuleInit {
@@ -15,13 +16,7 @@ export class InitCategoryService implements OnModuleInit {
     }
 
     private async createInitialCategories(): Promise<void> {
-        const categoryNames = [
-            { name: '영화', description: '영화 관련 카테고리' },
-            { name: '음악', description: '음악 관련 카테고리' },
-            { name: '책', description: '책 관련 카테고리' },
-        ];
-
-        for (const category of categoryNames) {
+        for (const category of defaultCategoryNames) {
             if (await this.checkCategoryNotExists(category.name)) {
                 const newCategory = this.categoryRepository.create(category);
                 await this.categoryRepository.save(newCategory);

--- a/src/modules/data/interest/InitInterestService.ts
+++ b/src/modules/data/interest/InitInterestService.ts
@@ -1,7 +1,7 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { InterestRepository} from "../../interest/repository/InterestRepository";
-import { Interest} from "../../interest/entity/Interest";
+import {defaultInterestNames} from "../../../constants/defaultInterests";
 
 @Injectable()
 export class InitInterestService implements OnModuleInit {
@@ -15,9 +15,7 @@ export class InitInterestService implements OnModuleInit {
     }
 
     private async createInitialInterests(): Promise<void> {
-        const interestNames = ['버럭', '까칠', '기쁨', '소심', '슬픔'];
-
-        for (const name of interestNames) {
+        for (const name of defaultInterestNames) {
             if (await this.checkInterestNotExists(name)) {
                 const interest = this.interestRepository.create({ name });
                 await this.interestRepository.save(interest);

--- a/src/modules/interest/dto/UserInterestDto.ts
+++ b/src/modules/interest/dto/UserInterestDto.ts
@@ -1,13 +1,11 @@
 import { Field } from '../../../utils/mapper/FieldNameExtractor';
-import { ResponseInterestDto } from './InterestDto'
-import {Interest} from "../entity/Interest";
 
 export class ResponseUserInterestDto {
     @Field
     id: number;
 
     @Field
-    interest: Interest;
+    name: string;
 
     @Field
     score: number;

--- a/src/modules/interest/entity/UserInterest.ts
+++ b/src/modules/interest/entity/UserInterest.ts
@@ -13,6 +13,9 @@ export class UserInterest {
     @ManyToOne(() => Interest, interest => interest.userInterests)
     interest: Interest;
 
+    @Column({nullable:true})
+    name: string;
+
     @Column({ type: 'int', default: 0 })
     score: number;
 }

--- a/src/modules/interest/repository/UserInterestRepository.ts
+++ b/src/modules/interest/repository/UserInterestRepository.ts
@@ -8,14 +8,14 @@ export class UserInterestRepository extends Repository<UserInterest> {
         super(UserInterest, dataSource.createEntityManager());
     }
 
-    async createUserInterest(userId: number, interestId: number, score: number): Promise<UserInterest> {
-        const userInterest = this.create({ user: { id: userId }, interest: { id: interestId }, score });
+    async createUserInterest(userId: number, interestId: number, score: number, name: string): Promise<UserInterest> {
+        const userInterest = this.create({ user: { id: userId }, interest: { id: interestId }, score ,name});
         return this.save(userInterest);
     }
     async findByUserId(userId: number): Promise<UserInterest[]> {
         return this.find({
             where: { user: { id: userId } },
-            relations: ['interest'],
+            relations: ['interest','user'],
         });
     }
 

--- a/src/modules/post/repository/PostRepository.ts
+++ b/src/modules/post/repository/PostRepository.ts
@@ -25,4 +25,10 @@ export class PostRepository extends Repository<Post> {
   async paginate(options: PaginationOptions, findOptions?: FindManyOptions<Post>): Promise<PaginationResult<Post>> {
     return paginate(this, options, findOptions);
   }
+  async removeInterestsFromPost(post: Post): Promise<void> {
+    await this.createQueryBuilder()
+        .relation(Post, 'interests')
+        .of(post)
+        .remove(post.interests);
+  }
 }

--- a/src/modules/post/service/PostService.ts
+++ b/src/modules/post/service/PostService.ts
@@ -50,7 +50,7 @@ export class PostService {
 
     if (user) {
       await this.interestService.incrementUserInterestScore(user.id, post.interests);
-      await this.categoryService.incrementUserCategoryScore(user.id, post.category.id);
+      await this.categoryService.incrementUserCategoryScore(user.id, post.category);
     }
 
     post.views++;
@@ -80,6 +80,7 @@ export class PostService {
 
   async remove(id: number): Promise<void> {
     const post = await this.postRepository.findById(id);
+    await this.postRepository.removeInterestsFromPost(post);
     await this.handleErrors(() => this.postRepository.delete(post.id), 'Failed to delete post');
   }
 

--- a/src/modules/user/service/UserService.ts
+++ b/src/modules/user/service/UserService.ts
@@ -3,12 +3,12 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { User } from "../entity/User";
 import {PostUserDto, ResponseUserDto, ResponseUserWithInterestsAndCategoriesDto, UpdateUserDto} from "../dto/UserDto";
 import { UserRepository } from "../repository/UserRepository";
-import { mapToDto } from "../../../utils/mapper/Mapper";
+import {mapToDto} from "../../../utils/mapper/Mapper";
 import {PaginationDto} from "../../../utils/pagination/paginationDto";
 import {PaginationResult} from "../../../utils/pagination/pagination";
 import {InterestService} from "../../interest/service/InterestService";
-import {ResponseUserInterestDto} from "../../interest/dto/UserInterestDto";
 import {CategoryService} from "../../category/service/CategoryService";
+import {ResponseUserInterestDto} from "../../interest/dto/UserInterestDto";
 import {ResponseUserCategoryDto} from "../../category/dto/UserCategoryDto";
 
 @Injectable()
@@ -34,16 +34,16 @@ export class UserService {
     }
 
     async findMe(email: string): Promise<ResponseUserWithInterestsAndCategoriesDto> {
-        const user = await this.userRepository.findByEmailWithInterestsAndCategories(email);
+        let user = await this.userRepository.findByEmailWithInterestsAndCategories(email);
         this.ensureExists(user, 0);
 
-        await this.interestService.addDefaultInterestsToUser(user);
-        await this.categoryService.addDefaultCategoriesToUser(user);
+        user = await this.interestService.addDefaultInterestsToUser(user);
+        user = await this.categoryService.addDefaultCategoriesToUser(user);
 
-        const userDto = mapToDto(user, ResponseUserWithInterestsAndCategoriesDto);
+        const userDto =  mapToDto(user, ResponseUserWithInterestsAndCategoriesDto);
 
-        userDto.userInterests = user.userInterests.map(ui => mapToDto(ui, ResponseUserInterestDto));
-        userDto.userCategories = user.userCategories.map(uc => mapToDto(uc, ResponseUserCategoryDto));
+        userDto.userInterests = user.userInterests.map(ui => mapToDto(ui,ResponseUserInterestDto));
+        userDto.userCategories = user.userCategories.map(uc => mapToDto(uc,ResponseUserCategoryDto));
 
         return userDto;
     }
@@ -80,6 +80,7 @@ export class UserService {
         const user = await this.findById(id);
         await this.checkError(() => this.userRepository.delete(user.id), 'Failed to delete user');
     }
+
 
     private ensureExists(user: User, id: number): void {
         if (!user) {

--- a/src/utils/mapper/Mapper.ts
+++ b/src/utils/mapper/Mapper.ts
@@ -17,3 +17,4 @@ export function mapToDto<Entity, Dto>(entity: Entity, dtoClass: new () => Dto): 
 
   return dto;
 }
+


### PR DESCRIPTION
## 새로 추가된 기능
### 카테고리 및 관심사 초기화 :
InitCategoryService: 영화, 음악, 책 카테고리를 초기화
InitInterestService: 버럭, 까칠, 기쁨, 소심, 슬픔 관심사를 초기화

### UserInterest 및 UserCategory 추가:
사용자가 로그인할 때 기본 관심사와 카테고리를 자동으로 추가
addDefaultInterestsToUser 및 addDefaultCategoriesToUser 메소드 구현

### Post 생성 시 관심사 및 카테고리 연관 관계 설정:
게시글을 생성할 때 선택된 관심사 및 카테고리를 연관 관계로 설정
PostService의 create 메소드에서 구현

### 게시글 조회 시 사용자 활동 기록 업데이트:
게시글을 조회할 때 사용자의 관심사 및 카테고리 점수를 증가
incrementUserInterestScore 및 incrementUserCategoryScore 메소드를 통해 구현

## 코드 리팩토링 및 최적화

### Repository에 관련 메소드 추가:
findByIdsForCreatePost: SQL Injection 방지를 위해 관심사 ID 배열로 관심사를 조회하는 메소드 추가
removeInterestsFromPost: 게시글의 연관된 관심사를 삭제하는 메소드 추가

### DTO 업데이트:
ResponsePostDto: 게시글 응답에 연관된 관심사를 포함하도록 수정.
PostPostDto: JSON에서 숫자 타입으로 변환하도록 수정.

### 서비스 책임 분리:
UserInterestRepository 및 UserCategoryRepository 로 사용자 관심사 및 카테고리 관련 기능을 분리.
각 서비스에서 관심사 및 카테고리 점수를 관리하도록 수정.

JWT 전달 방식 수정
이제 토큰을 header 로 전달함.

변경된 파일 목록
src/modules/auth/service/AuthService.ts
src/modules/category/entity/Category.ts
src/modules/category/service/CategoryService.ts
src/modules/interest/entity/Interest.ts
src/modules/interest/service/InterestService.ts
src/modules/interest/repository/InterestRepository.ts
src/modules/post/dto/PostPostDto.ts
src/modules/post/entity/Post.ts
src/modules/post/service/PostService.ts
src/modules/user/service/UserService.ts
src/modules/user/repository/UserInterestRepository.ts
src/utils/mapper/Mapper.ts
src/utils/pagination/pagination.ts
src/utils/pagination/paginationDto.ts